### PR TITLE
Added username and password while creating client

### DIFF
--- a/paho.mqtt.plugin.js
+++ b/paho.mqtt.plugin.js
@@ -135,6 +135,8 @@
 		}
 
 		var client = new Paho.MQTT.Client(currentSettings.server,
+										userName: currentSettings.username,
+										password: currentSettings.password,
 										currentSettings.port, 
 										currentSettings.client_id);
 		client.onConnectionLost = onConnectionLost;


### PR DESCRIPTION
The plugin worked well when you don't use Username and Password in Mosquitto. 
But If you use Username and Password, then the plugin would not instantiate without username and password. It only works when you You manually go to data-source settings every time and press save. Coz that triggers the function onSettingsChanged() wherer the Client reconnects with Username and Password. and it always worked when someone changes settings and saves.
So, In order to make it working the very first time, I added username and password while instantiating Paho.MQTT.Client at the beginning.  If the Broker allows client based on username/password or not. It will work in both cases.
